### PR TITLE
Update "create project issue" link

### DIFF
--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -25,7 +25,7 @@
 <a href="{{ $newPageURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_create_child_page" }}</a>
 <a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
 {{ if $gh_project_repo }}
-{{ $project_issueURL := printf "%s/issues/new" $gh_project_repo }}
+{{ $project_issueURL := printf "%s/issues/new/choose" $gh_project_repo }}
 <a href="{{ $project_issueURL }}" target="_blank"><i class="fas fa-tasks fa-fw"></i> {{ T "post_create_project_issue" }}</a>
 {{ end }}
 </div>


### PR DESCRIPTION
**Problema:**
Nossos repos open source, estão utilizando hoje, alguns templates para abrir issues. Porém o hugo linka diretamente a uma pagina de nova issue, sem nenhum template.

**Solução:**
Essa mudança que estou sugerindo, ira linkar diretamente para os templates de sugestão de aberturas de issues.

exemplo: 
* **beagle:** https://github.com/ZupIT/beagle/issues/new/choose
* **charles:** https://github.com/ZupIT/charlescd/issues/new/choose
* **ritchie:** https://github.com/ZupIT/ritchie-cli/issues/new/choose
